### PR TITLE
Feature/add test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _testmain.go
 .idea/
 *.iml
 .vscode/
+*.test

--- a/compression_test.go
+++ b/compression_test.go
@@ -65,6 +65,20 @@ func BenchmarkWriteWithCompression(b *testing.B) {
 	b.ReportAllocs()
 }
 
+func BenchmarkWriteWithCompressionOfContextTakeover(b *testing.B) {
+	w := ioutil.Discard
+	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)
+	messages := textMessages(100)
+	c.enableWriteCompression = true
+	c.contextTakeover = true
+	c.newCompressionWriter = compressContextTakeover
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.WriteMessage(TextMessage, messages[i%len(messages)])
+	}
+	b.ReportAllocs()
+}
+
 func TestValidCompressionLevel(t *testing.T) {
 	c := newConn(fakeNetConn{}, false, 1024, 1024)
 	for _, level := range []int{minCompressionLevel - 1, maxCompressionLevel + 1} {

--- a/conn_test.go
+++ b/conn_test.go
@@ -494,3 +494,14 @@ func TestBufioReuse(t *testing.T) {
 	}
 
 }
+
+func BenchmarkAddDict(b *testing.B) {
+	w := ioutil.Discard
+	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)
+	messages := textMessages(100)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.AddRxDict(messages[i%len(messages)])
+	}
+	b.ReportAllocs()
+}


### PR DESCRIPTION
wirte compression 

__before__

```
goos: darwin
goarch: amd64
pkg: github.com/smith-30/websocket
BenchmarkWriteWithCompressionOfContextTakeover-4   	   10000	    183590 ns/op	 1236691 B/op	      23 allocs/op
PASS
ok  	github.com/smith-30/websocket	1.869s
Success: Benchmarks passed.
```


__after__


```
goos: darwin
goarch: amd64
pkg: github.com/smith-30/websocket
BenchmarkWriteWithCompressionOfContextTakeover-4   	  300000	      4363 ns/op	     303 B/op	       3 allocs/op
PASS
ok  	github.com/smith-30/websocket	1.366s
Success: Benchmarks passed.
```